### PR TITLE
Implement checkhealth

### DIFF
--- a/lua/music-controls/health.lua
+++ b/lua/music-controls/health.lua
@@ -1,0 +1,34 @@
+local config = require('music-controls.config').config
+
+local M = {}
+
+local start = vim.health.start or vim.health.report_start
+local ok = vim.health.ok or vim.health.report_ok
+local warn = vim.health.warn or vim.health.report_warn
+local error = vim.health.error or vim.health.report_error
+
+local _check_playerctl_is_installed = function()
+  return vim.fn.executable('playerctl') == 1
+end
+
+local _check_default_player = function()
+  return config.default_player ~= ''
+end
+
+M.check = function()
+  start('Dependencies:')
+  if not _check_playerctl_is_installed() then
+    error('playerctl is not installed')
+  else
+    ok('playerctl is installed')
+  end
+
+  start('Config:')
+  if not _check_default_player() then
+    warn('Default player is not set')
+  else
+    ok('Default player is set')
+  end
+end
+
+return M


### PR DESCRIPTION
Some really basic checks, but it will do the trick for now. Just checking whether `playerctl` is installed, and a default player is configured. The last one will just trigger a warning since it isn't required for the plugin to work correctly.

![image](https://github.com/user-attachments/assets/609ff028-7b84-4e0b-94b6-d678f0db3228)
![image](https://github.com/user-attachments/assets/3c8a04be-99da-4d78-9778-3a755c318056)
