### PR TITLE
Fixed an issue in the lualine example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Refer to the documentation of your statusline plugin for more information.
 require('lualine').setup {
   sections = {
     lualine_x = {
-      require("music-controls")._statusline,
+      require("music-controls")._statusline(),
     }
   }
 }


### PR DESCRIPTION
Hello!
I found an issue in the README file regarding the lualine example.
It is supposed to be `require("music-controls")._statusline()`.